### PR TITLE
logrotate config for nemea supervisor and modules

### DIFF
--- a/ansible/inventory/host_files/staas-vagrant/logrotate.d/nemea-supervisor
+++ b/ansible/inventory/host_files/staas-vagrant/logrotate.d/nemea-supervisor
@@ -1,0 +1,18 @@
+/var/log/nemea-supervisor/modules_events /var/log/nemea-supervisor/modules_statistics /var/log/nemea-supervisor/supervisor_log_module_event /var/log/nemea-supervisor/supervisor_log_statistics /var/log/nemea-supervisor/supervisor_log {
+	missingok
+	sharedscripts
+	notifempty
+	compress
+	delaycompress
+	copytruncate
+}
+
+/var/log/nemea-supervisor/modules_logs/*_stderr /var/log/nemea-supervisor/modules_logs/*_stdout {
+	missingok
+	sharedscripts
+	notifempty
+	compress
+	delaycompress
+	copytruncate
+}
+


### PR DESCRIPTION
It's under test on our collector (and in casa).
It should rotate weakly (default value in /etc/logrotate.conf).